### PR TITLE
Fixes

### DIFF
--- a/code/game/gamemodes/miniantags/abduction/abduction.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction.dm
@@ -74,11 +74,11 @@
 		agent = preset_agent
 
 
-	scientist.assigned_role = "MODE"
+	scientist.assigned_role = "Abductor Scientist"
 	scientist.special_role = SPECIAL_ROLE_ABDUCTOR_SCIENTIST
 	log_game("[scientist.key] (ckey) has been selected as an abductor team [team_number] scientist.")
 
-	agent.assigned_role = "MODE"
+	agent.assigned_role = "Abductor Agent"
 	agent.special_role = SPECIAL_ROLE_ABDUCTOR_AGENT
 	log_game("[agent.key] (ckey) has been selected as an abductor team [team_number] agent.")
 
@@ -223,6 +223,7 @@
 
 	var/obj/item/device/radio/R = new /obj/item/device/radio/headset/syndicate/alt(agent)
 	R.set_frequency(radio_freq)
+	R.name = "strange headset"
 	agent.equip_to_slot_or_del(R, slot_l_ear)
 	agent.equip_to_slot_or_del(new /obj/item/clothing/shoes/combat(agent), slot_shoes)
 	agent.equip_to_slot_or_del(new /obj/item/clothing/under/color/grey(agent), slot_w_uniform) //they're greys gettit
@@ -287,7 +288,7 @@
 		var/datum/objective/objective = team_objectives[team_number]
 		var/team_name = team_names[team_number]
 		if(console.experiment.points >= objective.target_amount)
-			to_chat(world, "<span class='greenannounce'>[team_name] team fullfilled its mission!</span>")
+			to_chat(world, "<span class='greenannounce'>[team_name] team fulfilled its mission!</span>")
 		else
 			to_chat(world, "<span class='boldannounce'>[team_name] team failed its mission.</span>")
 	..()

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -84,6 +84,15 @@
 	burntime = 20
 	// TODO:  Special ash subtype that looks like charred chair legs
 
+/obj/structure/stool/bed/chair/wood/attack_animal(mob/living/simple_animal/user)
+	if(user.environment_smash)
+		user.do_attack_animation(src)
+		visible_message("<span class='danger'>[user] smashes [src] apart!</span>")
+		new /obj/item/stack/sheet/wood(get_turf(src))
+		new /obj/item/stack/sheet/wood(get_turf(src))
+		new /obj/item/stack/sheet/wood(get_turf(src))
+		qdel(src)
+
 /obj/structure/stool/bed/chair/wood/narsie_act()
 	return
 


### PR DESCRIPTION
Fixes #2709

Fixes a few minor problems with abductors, and yet another spelling issue.

:cl: Purpose2
fix: Animal broken wooden chairs no longer drop metal.
fix: Abductors no longer have Syndicate ties.
fix: Fixes Abductor round-end message.
/ :cl: